### PR TITLE
remove mssql-server-agent package

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -31,7 +31,6 @@
     state: latest
   with_items:
     - mssql-server
-    - mssql-server-agent
     - mssql-tools
     - unixodbc-dev
   environment:


### PR DESCRIPTION
The agent is now included in the **mssql-server** package and this role gives an error about an unmet dependency when installing the **mssql-server-agent** package. Anyway, there's no need to install it anymore so I've removed it.